### PR TITLE
Add OMT API support to Python bindings and extend Solver interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,7 @@ else()
   endif()
 endif()
 
-find_package(Python 3.6...3.10.999 COMPONENTS Interpreter REQUIRED)
+find_package(Python 3.6...3.13.999 COMPONENTS Interpreter REQUIRED)
 find_package(GMP 6.1 REQUIRED)
 
 if(ENABLE_ASAN)

--- a/contrib/requirements_python_dev.txt
+++ b/contrib/requirements_python_dev.txt
@@ -1,0 +1,6 @@
+setuptools
+Cython>=3.0.0
+pytest
+scikit-build
+pyparsing
+toml

--- a/src/api/cpp/cvc5.cpp
+++ b/src/api/cpp/cvc5.cpp
@@ -34,6 +34,7 @@
 
 #include <cstring>
 #include <sstream>
+#include <utility>
 
 #include "api/cpp/cvc5_checks.h"
 #include "base/check.h"
@@ -2877,6 +2878,57 @@ Term::const_iterator Term::end() const
   }
   return Term::const_iterator(d_nm, d_node, endpos);
 }
+
+OptimizationObjective::OptimizationObjective() : d_objective(nullptr) {}
+OptimizationObjective::OptimizationObjective(
+    const internal::smt::OptimizationObjective& obj)
+    : d_objective(new internal::smt::OptimizationObjective(obj))
+{
+}
+Term OptimizationObjective::getTarget() const
+{
+  return Term(internal::NodeManager::currentNM(), d_objective->getTarget());
+}
+bool OptimizationObjective::bvIsSigned() const
+{
+  return d_objective->bvIsSigned();
+}
+bool OptimizationObjective::isMinimize() const
+{
+  return d_objective->getType()
+         == internal::smt::OptimizationObjective::MINIMIZE;
+}
+bool OptimizationObjective::isMaximize() const
+{
+  return d_objective->getType()
+         == internal::smt::OptimizationObjective::MAXIMIZE;
+}
+
+OptimizationResult::OptimizationResult() : d_result(nullptr) {}
+OptimizationResult::OptimizationResult(
+    const internal::smt::OptimizationResult& res)
+    : d_result(new internal::smt::OptimizationResult(res))
+{
+}
+Result OptimizationResult::getResult() const
+{
+  return Result(d_result->getResult());
+}
+Term OptimizationResult::getValue() const
+{
+  return Term(internal::NodeManager::currentNM(), d_result->getValue());
+}
+bool OptimizationResult::isPosInfinity() const
+{
+  return d_result->isPosInfinity();
+}
+bool OptimizationResult::isNegInfinity() const
+{
+  return d_result->isNegInfinity();
+}
+bool OptimizationResult::isPosApprox() const { return d_result->isPosApprox(); }
+bool OptimizationResult::isNegApprox() const { return d_result->isNegApprox(); }
+bool OptimizationResult::isFinite() const { return d_result->isFinite(); }
 
 const internal::Node& Term::getNode(void) const { return *d_node; }
 
@@ -6621,6 +6673,20 @@ std::string Solver::getObjectives()
   // CVC5_API_RECOVERABLE_CHECK(d_opt_slv->isSmtModeSat())
   //     << "Cannot get objevtive unless after a SAT or UNKNOWN response.";
   return d_opt_slv->getObjectives();
+  CVC5_API_TRY_CATCH_END;
+}
+std::vector<std::pair<OptimizationObjective, OptimizationResult>>
+Solver::getObjectiveResults()
+{
+  CVC5_API_TRY_CATCH_BEGIN;
+  auto const& results = d_opt_slv->getObjectiveResults();
+  std::vector<std::pair<OptimizationObjective, OptimizationResult>> ans;
+  ans.reserve(results.size());
+  for (auto const& res : d_opt_slv->getObjectiveResults())
+  {
+    ans.emplace_back(OptimizationObjective(res.first), OptimizationResult(res.second));
+  }
+  return ans;
   CVC5_API_TRY_CATCH_END;
 }
 

--- a/src/api/cpp/cvc5.h
+++ b/src/api/cpp/cvc5.h
@@ -62,6 +62,8 @@ class SynthResult;
 class StatisticsRegistry;
 namespace smt{
   class OptimizationSolver; // anynomous author: optimization solver
+  class OptimizationObjective; // anynomous author: optimization objective
+  class OptimizationResult; // anynomous author: optimization result
 }
 }  // namespace internal
 
@@ -73,6 +75,8 @@ class Solver;
 class Statistics;
 struct APIStatistics;
 class Term;
+class OptimizationObjective;
+class OptimizationResult;
 
 /* -------------------------------------------------------------------------- */
 /* Exception                                                                  */
@@ -193,6 +197,7 @@ class CVC5_EXPORT CVC5ApiOptionException : public CVC5ApiRecoverableException
 class CVC5_EXPORT Result
 {
   friend class Solver;
+  friend class OptimizationResult;
 
  public:
   /** Constructor. */
@@ -1115,6 +1120,8 @@ class CVC5_EXPORT Term
   friend class Solver;
   friend class Grammar;
   friend class SynthResult;
+  friend class OptimizationObjective;
+  friend class OptimizationResult;
   friend struct std::hash<Term>;
 
  public:
@@ -1856,6 +1863,45 @@ template <typename V>
 std::ostream& operator<<(std::ostream& out,
                          const std::unordered_map<Term, V>& unordered_map)
     CVC5_EXPORT;
+
+/**
+ * A cvc5 optimization objective.
+ */
+class CVC5_EXPORT OptimizationObjective
+{
+  friend class Solver;
+ public:
+  OptimizationObjective();
+  Term getTarget() const;
+  bool bvIsSigned() const;
+  bool isMinimize() const;
+  bool isMaximize() const;
+
+ private:
+  OptimizationObjective(const internal::smt::OptimizationObjective& res);
+  std::shared_ptr<const internal::smt::OptimizationObjective> d_objective;
+};
+
+/**
+ * A cvc5 optimization result.
+ */
+class CVC5_EXPORT OptimizationResult
+{
+  friend class Solver;
+ public:
+  OptimizationResult();
+  Result getResult() const;
+  Term getValue() const;
+  bool isPosInfinity() const;
+  bool isNegInfinity() const;
+  bool isPosApprox() const;
+  bool isNegApprox() const;
+  bool isFinite() const;
+
+ private:
+  OptimizationResult(const internal::smt::OptimizationResult& res);
+  std::shared_ptr<const internal::smt::OptimizationResult> d_result;
+};
 
 }  // namespace cvc5
 
@@ -3973,6 +4019,7 @@ class CVC5_EXPORT Solver
   void maximizeFormula(const Term& term);
   void minimizeFormula(const Term& term);
   std::string getObjectives();
+  std::vector<std::pair<OptimizationObjective, OptimizationResult>> getObjectiveResults();
 
   /**
    * Check satisfiability.

--- a/src/api/python/CMakeLists.txt
+++ b/src/api/python/CMakeLists.txt
@@ -46,7 +46,7 @@ list(APPEND CMAKE_MODULE_PATH ${SKBUILD_CMAKE_MODULE_PATH})
 # 'PythonExtensions' is not yet compatible with cmake's new 'FindPython'.
 #     https://github.com/scikit-build/scikit-build/issues/506
 # We define the following symbols below to be backward compatible.
-find_package(Python 3.6...3.10.999 COMPONENTS Development)
+find_package(Python 3.6...3.13.999 COMPONENTS Development)
 
 # Since PythonExtensions still uses PythonInterp and PythonLibs, we have to
 # make sure that these modules find the same Python version that was found by

--- a/src/api/python/cvc5.pxd
+++ b/src/api/python/cvc5.pxd
@@ -203,6 +203,23 @@ cdef extern from "api/cpp/cvc5.h" namespace "cvc5":
         bint isUnknown() except +
         string toString() except +
 
+    cdef cppclass OptimizationObjective:
+        OptimizationObjective() except +;
+        Term getTarget() except +
+        bint bvIsSigned() except +;
+        bint isMinimize() except +;
+        bint isMaximize() except +;
+
+    cdef cppclass OptimizationResult:
+        OptimizationResult() except +;
+        Result getResult() except +;
+        Term getValue() except +;
+        bint isPosInfinity() except +;
+        bint isNegInfinity() except +;
+        bint isPosApprox() except +;
+        bint isNegApprox() except +;
+        bint isFinite() except +;
+
     cdef cppclass Solver:
         Solver() except +
         Sort getBooleanSort() except +
@@ -304,6 +321,7 @@ cdef extern from "api/cpp/cvc5.h" namespace "cvc5":
         void maximizeFormula(const Term& term) except +;
         void minimizeFormula(const Term& term) except +;
         string getObjectives() except +;
+        vector[pair[OptimizationObjective, OptimizationResult]] getObjectiveResults() except +;
         Result checkSat() except +
         Result checkSatAssuming(const vector[Term]& assumptions) except +
         Sort declareDatatype(const string& symbol, const vector[DatatypeConstructorDecl]& ctors)

--- a/src/api/python/cvc5.pxd
+++ b/src/api/python/cvc5.pxd
@@ -301,6 +301,9 @@ cdef extern from "api/cpp/cvc5.h" namespace "cvc5":
         Term mkVar(Sort sort) except +
         Term simplify(const Term& t) except +
         void assertFormula(Term term) except +
+        void maximizeFormula(const Term& term) except +;
+        void minimizeFormula(const Term& term) except +;
+        string getObjectives() except +;
         Result checkSat() except +
         Result checkSatAssuming(const vector[Term]& assumptions) except +
         Sort declareDatatype(const string& symbol, const vector[DatatypeConstructorDecl]& ctors)

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -22,6 +22,8 @@ from cvc5 cimport DatatypeDecl as c_DatatypeDecl
 from cvc5 cimport DatatypeSelector as c_DatatypeSelector
 from cvc5 cimport Result as c_Result
 from cvc5 cimport SynthResult as c_SynthResult
+from cvc5 cimport OptimizationObjective as c_OptimizationObjective
+from cvc5 cimport OptimizationResult as c_OptimizationResult
 from cvc5 cimport Op as c_Op
 from cvc5 cimport OptionInfo as c_OptionInfo
 from cvc5 cimport holds as c_holds
@@ -806,6 +808,101 @@ cdef class SynthResult:
     def __repr__(self):
         return self.cr.toString().decode()
 
+cdef class OptimizationObjective:
+    """
+        Encapsulation of an optimization objective.
+
+        Wrapper class for :cpp:class:`cvc5::OptimizationObjective`.
+    """
+    cdef c_OptimizationObjective co
+    cdef Solver solver
+    def __cinit__(self, solver):
+        self.co = c_OptimizationObjective()
+        self.solver = solver
+
+    def getTarget(self):
+        """
+            :return: The optimization objective.
+        """
+        cdef Term t = Term(self.solver)
+        t.cterm = self.co.getTarget()
+        return t
+
+    def bvIsSigned(self):
+        """
+            :return: True if the optimization objective is a signed bitvector.
+        """
+        return self.co.bvIsSigned()
+
+    def isMinimize(self):
+        """
+            :return: True if the optimization objective type is 'minimize'.
+        """
+        return self.co.isMinimize()
+
+    def isMaximize(self):
+        """
+            :return: True if the optimization objective type is 'maximize'.
+        """
+        return self.co.isMaximize()
+
+cdef class OptimizationResult:
+    """
+        Encapsulation of an optimization result.
+
+        Wrapper class for :cpp:class:`cvc5::OptimizationResult`.
+    """
+    cdef c_OptimizationResult cr
+    cdef Solver solver
+    def __cinit__(self, solver):
+        self.cr = c_OptimizationResult()
+        self.solver = solver
+
+    def getResult(self):
+        """
+            :return: the optimization result.
+        """
+        cdef Result r = Result()
+        r.cr = self.cr.getResult()
+        return r
+
+    def getValue(self):
+        """
+            :return: the optimal value.
+        """
+        cdef Term t = Term(self.solver)
+        t.cterm = self.cr.getValue()
+        return t
+
+    def isPosInfinity(self):
+        """
+            :return: True if the optimal value is (+ oo).
+        """
+        return self.cr.isPosInfinity()
+
+    def isNegInfinity(self):
+        """
+            :return: True if the optimal value is (- oo).
+        """
+        return self.cr.isNegInfinity()
+
+    def isPosApprox(self):
+        """
+            :return: True if the optimal value is (+ <value> eps).
+        """
+        return self.cr.isPosApprox()
+
+    def isNegApprox(self):
+        """
+            :return: True if the optimal value is (- <value> eps).
+        """
+        return self.cr.isNegApprox()
+
+    def isFinite(self):
+        """
+            :return: True if the optimal value is finite.
+        """
+        return self.cr.isFinite()
 
 cdef class Solver:
     """
@@ -1774,6 +1871,29 @@ cdef class Solver:
             :return: A string representation of objectives' status.
         """
         return self.csolver.getObjectives()
+
+    def getObjectiveResults(self):
+        """
+            Get the objectives' status in a structured way.
+
+            :return: A list of pairs <:py:class:`OptimizationObjective`, <:py:class:`OptimizationResult`>.
+        """
+        cdef OptimizationObjective py_objective
+        cdef OptimizationResult py_result
+        result_list = []
+
+        for c_pair in self.csolver.getObjectiveResults():
+            py_objective = OptimizationObjective(self)
+            py_objective.co = c_pair.first
+
+            py_result = OptimizationResult(self)
+            py_result.cr = c_pair.second
+
+            python_pair = (py_objective, py_result)
+            result_list.append(python_pair)
+
+        return result_list
+
 
     def checkSat(self):
         """

--- a/src/api/python/cvc5.pxi
+++ b/src/api/python/cvc5.pxi
@@ -1733,6 +1733,48 @@ cdef class Solver:
         """
         self.csolver.assertFormula(term.cterm)
 
+    def maximizeFormula(self, Term term):
+        """
+            Maximize a formula.
+
+            SMT-LIB:
+
+            .. code-block:: smtlib
+
+                ( maximize <term> )
+
+            :param term: The formula to maximize.
+        """
+        self.csolver.maximizeFormula(term.cterm)
+
+    def minimizeFormula(self, Term term):
+        """
+            Minimize a formula.
+
+            SMT-LIB:
+
+            .. code-block:: smtlib
+
+                ( minimize <term> )
+
+            :param term: The formula to minimize.
+        """
+        self.csolver.minimizeFormula(term.cterm)
+
+    def getObjectives(self):
+        """
+            Get the objectives' status.
+
+            SMT-LIB:
+
+            .. code-block:: smtlib
+
+                ( get-objectives <term> )
+
+            :return: A string representation of objectives' status.
+        """
+        return self.csolver.getObjectives()
+
     def checkSat(self):
         """
             Check satisfiability.

--- a/src/smt/optimization_solver.cpp
+++ b/src/smt/optimization_solver.cpp
@@ -437,6 +437,20 @@ std::string OptimizationSolver::getObjectives()
   ans += "\n)\n";
   return ans;
 }
+
+// anynomous author: get objective results
+std::vector<std::pair<OptimizationObjective, OptimizationResult>>
+OptimizationSolver::getObjectiveResults()
+{
+  std::vector<std::pair<OptimizationObjective, OptimizationResult>> ans;
+  ans.reserve(d_objectives.size());
+  for (size_t i = 0; i < d_objectives.size(); i++)
+  {
+    ans.emplace_back(d_objectives[i], d_results[i]);
+  }
+  return ans;
+}
+
 // anynomous author: check whether all objectives are not available
 bool OptimizationSolver::isSmtModeSat(){
   for(size_t i=0;i<d_results.size();i++){

--- a/src/smt/optimization_solver.h
+++ b/src/smt/optimization_solver.h
@@ -257,10 +257,17 @@ class OptimizationSolver : protected EnvObj
 
   /**
    * Returns the objectives after checkOpt is called
-   * @return a vector of Optimization Result,
+   * @return a vector of Optimization Result as string,
    *   each containing the outcome and the value.
    **/
   std::string getObjectives();
+
+  /**
+   * Returns the objectives after checkOpt is called
+   * @return a vector of Optimization Result as a pair <objective, value>
+   *   each containing the outcome and the value.
+   **/
+  std::vector<std::pair<OptimizationObjective, OptimizationResult>> getObjectiveResults();
 
     /**
    * Returns whether the objectives are available


### PR DESCRIPTION
This PR enhances the OMT API with the following improvements:

## Changes
- Added OMT API to python bindings
- Added `Solver::getObjectivesResults()` method that returns a vector of `<OptimizationObjective, OptimizationResult>` pairs, enabling easier access to optimization results.